### PR TITLE
Add Property Inspector project scaffold

### DIFF
--- a/NWAddons.sln
+++ b/NWAddons.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PropertyInspector", "PropertyInspector\PropertyInspector.csproj", "{00000000-0000-0000-0000-000000000002}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{00000000-0000-0000-0000-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{00000000-0000-0000-0000-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{00000000-0000-0000-0000-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{00000000-0000-0000-0000-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/PropertyInspector/Plugin.cs
+++ b/PropertyInspector/Plugin.cs
@@ -1,0 +1,25 @@
+using Autodesk.Navisworks.Api.Plugins;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PropertyInspector
+{
+    [Plugin("PropertyInspector", "NWAD", DisplayName = "Property Inspector", ToolTip = "Inspect and colorize model properties"),
+     DockPanePlugin(400, 300, AutoVisible = true)]
+    public class Plugin : DockPanePlugin
+    {
+        private PropertyInspectorControl? _control;
+
+        public override Control CreateControlPane()
+        {
+            _control = new PropertyInspectorControl();
+            return _control;
+        }
+
+        public override void DestroyControlPane(Control pane)
+        {
+            _control = null;
+            base.DestroyControlPane(pane);
+        }
+    }
+}

--- a/PropertyInspector/Properties/AssemblyInfo.cs
+++ b/PropertyInspector/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("PropertyInspector")]
+[assembly: AssemblyProduct("PropertyInspector")]
+[assembly: ComVisible(false)]
+[assembly: Guid("00000000-0000-0000-0000-000000000001")]

--- a/PropertyInspector/PropertyAggregator.cs
+++ b/PropertyInspector/PropertyAggregator.cs
@@ -1,0 +1,29 @@
+using Autodesk.Navisworks.Api;
+using System.Collections.Generic;
+
+namespace PropertyInspector
+{
+    public static class PropertyAggregator
+    {
+        public static void ScanModel(bool useSelection = false)
+        {
+            // TODO: Implement property aggregation logic.
+            Document doc = Application.ActiveDocument;
+            ModelItemCollection items = useSelection ?
+                doc.CurrentSelection.SelectedItems :
+                doc.Models.RootItems;
+
+            // Placeholder loops for compilation
+            foreach (ModelItem item in items)
+            {
+                foreach (PropertyCategory category in item.PropertyCategories)
+                {
+                    foreach (DataProperty property in category.Properties)
+                    {
+                        // Collect unique properties and values
+                    }
+                }
+            }
+        }
+    }
+}

--- a/PropertyInspector/PropertyInspector.csproj
+++ b/PropertyInspector/PropertyInspector.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Autodesk.Navisworks.Api">
+      <HintPath>$(ProgramFiles)\Autodesk\Navisworks Manage 2024\Autodesk.Navisworks.Api.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Autodesk.Navisworks.Api.Interop">
+      <HintPath>$(ProgramFiles)\Autodesk\Navisworks Manage 2024\Autodesk.Navisworks.Api.Interop.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Autodesk.Navisworks.Application">
+      <HintPath>$(ProgramFiles)\Autodesk\Navisworks Manage 2024\Autodesk.Navisworks.Application.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="System.Xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="PropertyInspectorControl.xaml" />
+  </ItemGroup>
+</Project>

--- a/PropertyInspector/PropertyInspectorControl.xaml
+++ b/PropertyInspector/PropertyInspectorControl.xaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="PropertyInspector.PropertyInspectorControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Margin="5">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Button x:Name="ScanButton" Content="Scan Model" Width="100" Margin="0,0,0,5" />
+        <Grid Grid.Row="1" Margin="0,5,0,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TreeView x:Name="PropertyTree" Grid.Column="0" />
+            <ListBox x:Name="ValueList" Grid.Column="1" />
+        </Grid>
+        <ComboBox x:Name="ColorPicker" Grid.Row="2" Margin="0,5,0,0">
+            <ComboBoxItem Content="Red" />
+            <ComboBoxItem Content="Green" />
+            <ComboBoxItem Content="Blue" />
+        </ComboBox>
+    </Grid>
+</UserControl>

--- a/PropertyInspector/PropertyInspectorControl.xaml.cs
+++ b/PropertyInspector/PropertyInspectorControl.xaml.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PropertyInspector
+{
+    public partial class PropertyInspectorControl : UserControl
+    {
+        public PropertyInspectorControl()
+        {
+            InitializeComponent();
+            ScanButton.Click += ScanButton_Click;
+        }
+
+        private void ScanButton_Click(object sender, RoutedEventArgs e)
+        {
+            PropertyAggregator.ScanModel();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add initial Property Inspector add-in project with DockPanePlugin entry point
- Provide WPF dock pane layout with scan button, property tree, value list, and color picker
- Stub property aggregation logic for scanning model property categories

## Testing
- `dotnet build PropertyInspector/PropertyInspector.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa795c2d208321a27abbee0ba4cb00